### PR TITLE
Consolidated diff cursor

### DIFF
--- a/subprojects/store/src/main/java/tools/refinery/store/map/ConsolidatedDiffCursor.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/map/ConsolidatedDiffCursor.java
@@ -1,10 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The Refinery Authors <https://refinery.tools/>
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package tools.refinery.store.map;
 
 import java.util.AbstractMap;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.HashMap;
+import java.util.Objects;
 
-public class ConsolidatedDiffCursor<K, V> implements DiffCursor<K, V> {
+class ConsolidatedDiffCursor<K, V> implements DiffCursor<K, V> {
 
 	private final DiffCursor<K, V> wrappedDiffCursor;
 	private DiffEntry<K, V>[] diff;
@@ -58,7 +64,7 @@ public class ConsolidatedDiffCursor<K, V> implements DiffCursor<K, V> {
 			var storedChange = consolidatedChanges.get(wrappedDiffCursor.getKey());
 			V fromValue;
 			if (storedChange != null) {
-				if (!storedChange.getValue().equals(wrappedDiffCursor.getFromValue())) {
+				if (!Objects.equals(storedChange.getValue(), wrappedDiffCursor.getFromValue())) {
 					throw new IllegalStateException("Inconsistent diff cursor: mismatched previous value and from value");
 				}
 				fromValue = storedChange.getKey();
@@ -67,7 +73,7 @@ public class ConsolidatedDiffCursor<K, V> implements DiffCursor<K, V> {
 			}
 			V toValue = wrappedDiffCursor.getToValue();
 
-			if (fromValue.equals(toValue)) {
+			if (Objects.equals(fromValue, toValue)) {
 				consolidatedChanges.remove(wrappedDiffCursor.getKey());
 			} else {
 				consolidatedChanges.put(wrappedDiffCursor.getKey(), new SimpleEntry<>(fromValue, toValue));

--- a/subprojects/store/src/main/java/tools/refinery/store/map/ConsolidatedDiffCursor.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/map/ConsolidatedDiffCursor.java
@@ -1,0 +1,84 @@
+package tools.refinery.store.map;
+
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashMap;
+
+public class ConsolidatedDiffCursor<K, V> implements DiffCursor<K, V> {
+
+	private final DiffCursor<K, V> wrappedDiffCursor;
+	private DiffEntry<K, V>[] diff;
+	private int cursorIndex = -1;
+
+	private record DiffEntry<K, V>(K key, V from, V to) {
+	}
+
+	public ConsolidatedDiffCursor(DiffCursor<K, V> diffCursor) {
+		wrappedDiffCursor = diffCursor;
+	}
+
+	@Override
+	public K getKey() {
+		return diff != null && 0 <= cursorIndex && cursorIndex < diff.length ? diff[cursorIndex].key : null;
+	}
+
+	@Override
+	public V getValue() {
+		return getToValue();
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return diff != null && cursorIndex >= diff.length;
+	}
+
+	@Override
+	public boolean move() {
+		if (diff == null) {
+			consolidate();
+		}
+
+		cursorIndex++;
+		return cursorIndex < diff.length;
+	}
+
+	@Override
+	public V getFromValue() {
+		return diff != null && 0 <= cursorIndex && cursorIndex < diff.length ? diff[cursorIndex].from : null;
+	}
+
+	@Override
+	public V getToValue() {
+		return diff != null && 0 <= cursorIndex && cursorIndex < diff.length ? diff[cursorIndex].to : null;
+	}
+
+	private void consolidate() {
+		HashMap<K, AbstractMap.SimpleEntry<V, V>> consolidatedChanges = new HashMap<>();
+		while (wrappedDiffCursor.move()) {
+			var storedChange = consolidatedChanges.get(wrappedDiffCursor.getKey());
+			V fromValue;
+			if (storedChange != null) {
+				if (!storedChange.getValue().equals(wrappedDiffCursor.getFromValue())) {
+					throw new IllegalStateException("Inconsistent diff cursor: mismatched previous value and from value");
+				}
+				fromValue = storedChange.getKey();
+			} else {
+				fromValue = wrappedDiffCursor.getFromValue();
+			}
+			V toValue = wrappedDiffCursor.getToValue();
+
+			if (fromValue.equals(toValue)) {
+				consolidatedChanges.remove(wrappedDiffCursor.getKey());
+			} else {
+				consolidatedChanges.put(wrappedDiffCursor.getKey(), new SimpleEntry<>(fromValue, toValue));
+			}
+		}
+
+		diff = new DiffEntry[consolidatedChanges.size()];
+		int i = 0;
+		for (var entry : consolidatedChanges.entrySet()) {
+			diff[i] = new DiffEntry<>(entry.getKey(), entry.getValue().getKey(), entry.getValue().getValue());
+			i++;
+		}
+	}
+}

--- a/subprojects/store/src/main/java/tools/refinery/store/map/VersionedMap.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/map/VersionedMap.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2023 The Refinery Authors <https://refinery.tools/>
+ * SPDX-FileCopyrightText: 2021-2026 The Refinery Authors <https://refinery.tools/>
  *
  * SPDX-License-Identifier: EPL-2.0
  */

--- a/subprojects/store/src/main/java/tools/refinery/store/map/VersionedMap.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/map/VersionedMap.java
@@ -17,4 +17,11 @@ public non-sealed interface VersionedMap<K, V> extends AnyVersionedMap {
 	void putAll(Cursor<K, V> cursor);
 
 	DiffCursor<K, V> getDiffCursor(Version state);
+
+	default DiffCursor<K, V> getDiffCursor(Version state, boolean consolidate) {
+		if (!consolidate) {
+			return getDiffCursor(state);
+		}
+		return new ConsolidatedDiffCursor<>(getDiffCursor(state));
+	}
 }

--- a/subprojects/store/src/main/java/tools/refinery/store/map/internal/state/VersionedMapStateImpl.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/map/internal/state/VersionedMapStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 The Refinery Authors <https://refinery.tools/>
+ * SPDX-FileCopyrightText: 2023-2026 The Refinery Authors <https://refinery.tools/>
  *
  * SPDX-License-Identifier: EPL-2.0
  */

--- a/subprojects/store/src/main/java/tools/refinery/store/map/internal/state/VersionedMapStateImpl.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/map/internal/state/VersionedMapStateImpl.java
@@ -82,7 +82,7 @@ public class VersionedMapStateImpl<K, V> implements VersionedMap<K, V> {
 			while (keyIterator.hasNext()) {
 				var key = keyIterator.next();
 				var value = valueIterator.next();
-				this.put(key,value);
+				this.put(key, value);
 			}
 		} else {
 			while (cursor.move()) {
@@ -122,6 +122,10 @@ public class VersionedMapStateImpl<K, V> implements VersionedMap<K, V> {
 		return new MapDiffCursor<>(this.defaultValue, fromCursor, toCursor);
 	}
 
+	@Override
+	public DiffCursor<K, V> getDiffCursor(Version state, boolean consolidate) {
+		return getDiffCursor(state);
+	}
 
 	@Override
 	public Version commit() {
@@ -157,7 +161,7 @@ public class VersionedMapStateImpl<K, V> implements VersionedMap<K, V> {
 	@Override
 	public int contentHashCode(ContentHashCode mode) {
 		// Calculating the root hashCode is always fast, because {@link Node} caches its hashCode.
-		if(root == null) {
+		if (root == null) {
 			return 0;
 		} else {
 			return root.hashCode();

--- a/subprojects/store/src/main/java/tools/refinery/store/model/Interpretation.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/model/Interpretation.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2023 The Refinery Authors <https://refinery.tools/>
+ * SPDX-FileCopyrightText: 2021-2026 The Refinery Authors <https://refinery.tools/>
  *
  * SPDX-License-Identifier: EPL-2.0
  */
@@ -25,7 +25,11 @@ public non-sealed interface Interpretation<T> extends AnyInterpretation {
 
 	void putAll(Cursor<Tuple, T> cursor);
 
-	DiffCursor<Tuple, T> getDiffCursor(Version to);
+	default DiffCursor<Tuple, T> getDiffCursor(Version to) {
+		return getDiffCursor(to, false);
+	}
+
+	DiffCursor<Tuple, T> getDiffCursor(Version to, boolean consolidate);
 
 	void addListener(InterpretationListener<T> listener, boolean alsoWhenRestoring);
 

--- a/subprojects/store/src/main/java/tools/refinery/store/model/Model.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/model/Model.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2023 The Refinery Authors <https://refinery.tools/>
+ * SPDX-FileCopyrightText: 2021-2026 The Refinery Authors <https://refinery.tools/>
  *
  * SPDX-License-Identifier: EPL-2.0
  */
@@ -29,7 +29,11 @@ public interface Model extends Versioned, AutoCloseable {
 
 	<T> Interpretation<T> getInterpretation(Symbol<T> symbol);
 
-	ModelDiffCursor getDiffCursor(Version to);
+	default ModelDiffCursor getDiffCursor(Version to) {
+		return getDiffCursor(to, false);
+	}
+
+	ModelDiffCursor getDiffCursor(Version to, boolean consolidate);
 
 	<T extends ModelAdapter> Optional<T> tryGetAdapter(Class<? extends T> adapterType);
 

--- a/subprojects/store/src/main/java/tools/refinery/store/model/internal/ModelImpl.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/model/internal/ModelImpl.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2023 The Refinery Authors <https://refinery.tools/>
+ * SPDX-FileCopyrightText: 2021-2026 The Refinery Authors <https://refinery.tools/>
  *
  * SPDX-License-Identifier: EPL-2.0
  */
@@ -60,11 +60,12 @@ public class ModelImpl implements Model {
 	}
 
 	@Override
-	public ModelDiffCursor getDiffCursor(Version to) {
+	public ModelDiffCursor getDiffCursor(Version to, boolean consolidate) {
 		var diffCursors = HashMap.<AnySymbol, DiffCursor<?, ?>>newHashMap(interpretations.size());
 		int i = 0;
 		for (var entry : interpretations.entrySet()) {
-			diffCursors.put(entry.getKey(), entry.getValue().getDiffCursor(ModelVersion.getInternalVersion(to, i++)));
+			diffCursors.put(entry.getKey(), entry.getValue().getDiffCursor(ModelVersion.getInternalVersion(to, i++),
+					consolidate));
 		}
 		return new ModelDiffCursor(diffCursors);
 	}

--- a/subprojects/store/src/main/java/tools/refinery/store/model/internal/VersionedInterpretation.java
+++ b/subprojects/store/src/main/java/tools/refinery/store/model/internal/VersionedInterpretation.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2023 The Refinery Authors <https://refinery.tools/>
+ * SPDX-FileCopyrightText: 2021-2026 The Refinery Authors <https://refinery.tools/>
  *
  * SPDX-License-Identifier: EPL-2.0
  */
@@ -106,8 +106,8 @@ public abstract class VersionedInterpretation<T> implements Interpretation<T> {
 	}
 
 	@Override
-	public DiffCursor<Tuple, T> getDiffCursor(Version to) {
-		return map.getDiffCursor(to);
+	public DiffCursor<Tuple, T> getDiffCursor(Version to, boolean consolidate) {
+		return map.getDiffCursor(to, consolidate);
 	}
 
 	Version commit() {

--- a/subprojects/store/src/test/java/tools/refinery/store/map/tests/fuzz/DiffCursorFuzzTest.java
+++ b/subprojects/store/src/test/java/tools/refinery/store/map/tests/fuzz/DiffCursorFuzzTest.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2023 The Refinery Authors <https://refinery.tools/>
+ * SPDX-FileCopyrightText: 2021-2026 The Refinery Authors <https://refinery.tools/>
  *
  * SPDX-License-Identifier: EPL-2.0
  */

--- a/subprojects/store/src/test/java/tools/refinery/store/map/tests/fuzz/DiffCursorFuzzTest.java
+++ b/subprojects/store/src/test/java/tools/refinery/store/map/tests/fuzz/DiffCursorFuzzTest.java
@@ -10,7 +10,11 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tools.refinery.store.map.*;
+import tools.refinery.store.map.DiffCursor;
+import tools.refinery.store.map.Version;
+import tools.refinery.store.map.VersionedMap;
+import tools.refinery.store.map.VersionedMapStore;
+import tools.refinery.store.map.VersionedMapStoreFactoryBuilder;
 import tools.refinery.store.map.tests.fuzz.utils.FuzzTestUtils;
 import tools.refinery.store.map.tests.utils.MapTestEnvironment;
 
@@ -19,13 +23,20 @@ import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
-import static tools.refinery.store.map.tests.fuzz.utils.FuzzTestCollections.*;
+import static tools.refinery.store.map.tests.fuzz.utils.FuzzTestCollections.commitFrequencyOptions;
+import static tools.refinery.store.map.tests.fuzz.utils.FuzzTestCollections.keyCounts;
+import static tools.refinery.store.map.tests.fuzz.utils.FuzzTestCollections.nullDefaultOptions;
+import static tools.refinery.store.map.tests.fuzz.utils.FuzzTestCollections.randomSeedOptions;
+import static tools.refinery.store.map.tests.fuzz.utils.FuzzTestCollections.storeConfigs;
+import static tools.refinery.store.map.tests.fuzz.utils.FuzzTestCollections.valueCounts;
 
 class DiffCursorFuzzTest {
 	private void runFuzzTest(String scenario, int seed, int steps, int maxKey, int maxValue, boolean nullDefault,
-							 int commitFrequency, boolean commitBeforeDiffCursor,
-							 VersionedMapStoreFactoryBuilder<Integer, String> builder) {
+	                         int commitFrequency, boolean commitBeforeDiffCursor,
+	                         VersionedMapStoreFactoryBuilder<Integer, String> builder) {
 		String[] values = MapTestEnvironment.prepareValues(maxValue, nullDefault);
 
 		VersionedMapStore<Integer, String> store = builder.defaultValue(values[0]).build().createOne();
@@ -34,11 +45,11 @@ class DiffCursorFuzzTest {
 	}
 
 	private void iterativeRandomPutsAndCommitsThenDiffCursor(String scenario, VersionedMapStore<Integer, String> store,
-															 int steps, int maxKey, String[] values, int seed,
-															 int commitFrequency, boolean commitBeforeDiffCursor) {
+	                                                         int steps, int maxKey, String[] values, int seed,
+	                                                         int commitFrequency, boolean commitBeforeDiffCursor) {
 
 		int largestCommit = -1;
-		Map<Integer,Version> index2Version = new HashMap<>();
+		Map<Integer, Version> index2Version = new HashMap<>();
 
 		{
 			// 1. build a map with versions
@@ -56,7 +67,7 @@ class DiffCursorFuzzTest {
 				}
 				if (index % commitFrequency == 0) {
 					Version version = versioned.commit();
-					index2Version.put(index,version);
+					index2Version.put(index, version);
 					largestCommit = index;
 				}
 				if (index % 10000 == 0)
@@ -78,12 +89,27 @@ class DiffCursorFuzzTest {
 
 					VersionedMap<Integer, String> oracle = store.createMap(index2Version.get(travelToVersion));
 
-					if(commitBeforeDiffCursor) {
+					if (commitBeforeDiffCursor) {
 						moving.commit();
 					}
 					DiffCursor<Integer, String> diffCursor = moving.getDiffCursor(index2Version.get(travelToVersion));
+
+					DiffCursor<Integer, String> consolidatedDiffCursor =
+							moving.getDiffCursor(index2Version.get(travelToVersion), true);
+					HashMap<Integer, String> consolidatedToValues = new HashMap<>();
+					while (consolidatedDiffCursor.move()) {
+						assertEquals(moving.get(consolidatedDiffCursor.getKey()),
+								consolidatedDiffCursor.getFromValue());
+						assertFalse(consolidatedToValues.containsKey(consolidatedDiffCursor.getKey()));
+						consolidatedToValues.put(consolidatedDiffCursor.getKey(), consolidatedDiffCursor.getToValue());
+					}
+
 					moving.putAll(diffCursor);
 					moving.commit();
+
+					for (var entry : consolidatedToValues.entrySet()) {
+						assertEquals(moving.get(entry.getKey()), entry.getValue());
+					}
 
 					MapTestEnvironment.compareTwoMaps(scenario + ":c" + index, oracle, moving);
 
@@ -114,15 +140,15 @@ class DiffCursorFuzzTest {
 	@Timeout(value = 10)
 	@Tag("fuzz")
 	void parametrizedFuzz(int ignoredTests, int steps, int noKeys, int noValues, boolean nullDefault,
-						  int commitFrequency, int seed, boolean commitBeforeDiffCursor,
-						  VersionedMapStoreFactoryBuilder<Integer, String> builder) {
+	                      int commitFrequency, int seed, boolean commitBeforeDiffCursor,
+	                      VersionedMapStoreFactoryBuilder<Integer, String> builder) {
 		runFuzzTest("DiffCursorS" + steps + "K" + noKeys + "V" + noValues + "s" + seed, seed, steps,
 				noKeys, noValues, nullDefault, commitFrequency, commitBeforeDiffCursor, builder);
 	}
 
 	static Stream<Arguments> parametrizedFuzz() {
 		return FuzzTestUtils.permutationWithSize(new Object[]{100}, keyCounts, valueCounts, nullDefaultOptions,
-				commitFrequencyOptions, randomSeedOptions, new Object[]{false,true}, storeConfigs);
+				commitFrequencyOptions, randomSeedOptions, new Object[]{false, true}, storeConfigs);
 	}
 
 	@ParameterizedTest(name = title)
@@ -130,7 +156,7 @@ class DiffCursorFuzzTest {
 	@Tag("fuzz")
 	@Tag("slow")
 	void parametrizedSlowFuzz(int ignoredTests, int steps, int noKeys, int noValues, boolean nullDefault, int commitFrequency,
-			int seed, boolean commitBeforeDiffCursor, VersionedMapStoreFactoryBuilder<Integer, String> builder) {
+	                          int seed, boolean commitBeforeDiffCursor, VersionedMapStoreFactoryBuilder<Integer, String> builder) {
 		runFuzzTest("DiffCursorS" + steps + "K" + noKeys + "V" + noValues + "s" + seed, seed, steps, noKeys, noValues,
 				nullDefault, commitFrequency, commitBeforeDiffCursor, builder);
 	}


### PR DESCRIPTION
This PR adds a consolidated wrapper diff cursor that consolidates all changes by key: that is, the final diff is computed based on the wrapped diff cursor. It iterates (curses:) on the wrapped cursor on first move call and collects all changes by key to finally only include one diff entry per key. Iterating on a consolidated diff cursor only returns each affected key once and the from value is the value of the key in the original version of the map and the to value is the value of the key in the other version of the map.

This cursor is only useful when having a delta diff cursor which lists all change deltas: this way, a delta diff cursor may contain several transactions regarding the same key. Using the consolidated diff cursor, this internal behavior can be hidden.

The state-based map diff cursor overrides the consolidating function to skip the unnecessary consolidated wrapper.